### PR TITLE
Update alias-config.c

### DIFF
--- a/src/plugins/alias/alias-config.c
+++ b/src/plugins/alias/alias-config.c
@@ -41,6 +41,7 @@ char *alias_default[][3] =
   { "CLOSE",   "buffer close",         NULL            },
   { "CHAT",    "dcc chat",             NULL            },
   { "EXIT",    "quit",                 NULL            },
+  { "GHOST",   "msg NickServ GHOST $1 $2", NULL        },
   { "IG",      "ignore",               NULL            },
   { "J",       "join",                 NULL            },
   { "K",       "kick",                 NULL            },


### PR DESCRIPTION
Update of alias-config.c for Weechat to support /ghost by default